### PR TITLE
fix: Unquote prefix variable before inserting it into magit-dispatch

### DIFF
--- a/magit-pre-commit.el
+++ b/magit-pre-commit.el
@@ -371,7 +371,7 @@ If HOOK is provided, run only that hook."
   (define-key magit-mode-map magit-pre-commit-transient-prefix #'magit-pre-commit)
   ;; Add to magit-dispatch for discoverability
   (transient-insert-suffix 'magit-dispatch "!"
-    '(magit-pre-commit-transient-prefix "Pre-commit" magit-pre-commit :if magit-pre-commit-available-p))
+    `(,magit-pre-commit-transient-prefix "Pre-commit" magit-pre-commit :if magit-pre-commit-available-p))
   ;; Add status section hook
   (magit-add-section-hook 'magit-status-sections-hook
                           #'magit-pre-commit--status-insert-section


### PR DESCRIPTION
`transient-insert-suffix` expects a key but receives a variable, when `magit-pre-commit-transient-prefix` is not unquoted. This causes `magit-dispatch` to return an error.