### PR TITLE
Compatiblity fix for transient 0.12 (magit 4.5)

### DIFF
--- a/magit-pre-commit.el
+++ b/magit-pre-commit.el
@@ -386,8 +386,8 @@ To enable, add to your init file:
   ;; Add to magit-dispatch for discoverability
   (transient-insert-suffix 'magit-dispatch "!"
     (list magit-pre-commit-transient-prefix
+          'magit-pre-commit
           :description "Pre-commit"
-          :command 'magit-pre-commit
           :if 'magit-pre-commit-available-p))
   ;; Add status section hook
   (magit-add-section-hook 'magit-status-sections-hook


### PR DESCRIPTION
When using the aforementioned version of `transient`, I get this error when starting magit on any repo:
```
transient--parse-suffix: Need command, argument, ‘:info’, ‘:info*’ or ‘:cons’; got ‘:description’
```

I suspect there might be some compatibility issue.

The change in this PR fixes the problem for me, but I'm not very confident about what's going on...

HTH  :slightly_smiling_face: 